### PR TITLE
Allow ".dv" suffix to be a valid mrc file for stitching

### DIFF
--- a/src/stitch_m/file_handler.py
+++ b/src/stitch_m/file_handler.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import re
 import logging
 
+VALID_IMAGE_SUFFIXES = (".mrc", ".dv")
 
 marker_regex = re.compile(r'(.*)marker(.*).txt$', flags=re.I)
 
@@ -45,7 +46,7 @@ def get_mrc_file(arg, return_data=False):
                 from numpy import genfromtxt
                 location_array = genfromtxt(csvfile, delimiter=",")
         
-        if os.path.splitext(mrc_path)[1].lower() == ".mrc":
+        if os.path.splitext(mrc_path)[1].lower() in VALID_IMAGE_SUFFIXES:
             if not os.path.exists(mrc_path):
                 msg = (
                     "Cannot find %s, so the current directory will be tried",


### PR DESCRIPTION
Allows for ".dv" files to be stitched, keeping compatibility with recent changes in Cockpit that adds more metadata to the mosaic images https://github.com/microscope-cockpit/cockpit/commit/df8f1f09ff59c20248d2e538be25be9607068768

This does not use this metadata, however, which would be useful as it would bypass the need for filtering.