### PR TITLE
Run GH action on PR or push to master only

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,6 +5,7 @@ name: Python package
 
 on:
   push:
+    branches: master
   pull_request:
     types: [ review_requested, synchronize ]
 


### PR DESCRIPTION
It's been running twice in PRs, e.g. https://github.com/DiamondLightSource/StitchM/pull/16. This should ignore pushes that aren't to master.